### PR TITLE
added pX_ make files

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,0 +1,54 @@
+source("1_fetch/src/download_nwis_site_data.R")
+source("1_fetch/src/nwis_site_info.R")
+source("1_fetch/src/bind_site_data.R")
+
+
+
+# For each site, download data and write to csv
+p1_targets_list <- list(
+  tar_target(
+    p1_site_data_01427207, 
+    download_nwis_site_data(site_num = "01427207",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate)
+  ),
+  tar_target(
+    p1_site_data_01432160,
+    download_nwis_site_data(site_num = "01432160",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate)
+  ),
+  tar_target(
+    p1_site_data_01436690,
+    download_nwis_site_data(site_num = "01436690",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate)
+  ),
+  tar_target(
+    p1_site_data_01466500,
+    download_nwis_site_data(site_num = "01466500",
+                            parameterCd = parameterCd,
+                            startDate = startDate,
+                            endDate = endDate)
+  ),
+  tar_target(
+    # Merge data from all sites
+    p1_site_data_csv,
+    bind_site_data(out_file = "1_fetch/out/nwis_site_data.csv",
+                   in_data = bind_rows(p1_site_data_01427207, 
+                                       p1_site_data_01432160,
+                                       p1_site_data_01436690,
+                                       p1_site_data_01466500)),
+    format = "file"
+  ),
+  tar_target(
+    # Download pertinent site information for each site
+    p1_site_info_csv,
+    nwis_site_info(out_file = "1_fetch/out/site_info.csv", 
+                   site_data_file = p1_site_data_csv),
+    format = "file"
+  )
+)

--- a/1_fetch/src/bind_site_data.R
+++ b/1_fetch/src/bind_site_data.R
@@ -1,5 +1,6 @@
 # This function binds together the site data objects.
 bind_site_data <- function(out_file, in_data){
+  require(tidyverse)
   
   in_data %>% 
     readr::write_csv(file = out_file)

--- a/1_fetch/src/bind_site_data.R
+++ b/1_fetch/src/bind_site_data.R
@@ -1,6 +1,5 @@
 # This function binds together the site data objects.
 bind_site_data <- function(out_file, in_data){
-  require(tidyverse)
   
   in_data %>% 
     readr::write_csv(file = out_file)

--- a/1_fetch/src/download_nwis_site_data.R
+++ b/1_fetch/src/download_nwis_site_data.R
@@ -3,10 +3,10 @@
 download_nwis_site_data <- function(site_num, parameterCd, startDate, endDate, out_file){
   
   # readNWISdata is from the dataRetrieval package
-  data_out <- readNWISdata(sites=site_num, service="iv", 
-                           parameterCd = parameterCd, 
-                           startDate = startDate, 
-                           endDate = endDate)
+  data_out <- dataRetrieval::readNWISdata(sites=site_num, service="iv", 
+                                          parameterCd = parameterCd, 
+                                          startDate = startDate, 
+                                          endDate = endDate)
 
   # -- simulating a failure-prone web-sevice here, do not edit --
   set.seed(Sys.time())

--- a/2_process.R
+++ b/2_process.R
@@ -1,0 +1,12 @@
+source("2_process/src/process_and_style.R")
+
+# Process and annotate site_data
+p2_targets_list <- list(
+  tar_target(
+    p2_site_data_styled_rds,
+    process_data(site_data_file = p1_site_data_csv, 
+                 site_info_file = p1_site_info_csv,
+                 out_file = "2_process/out/processed_data.rds"),
+    format = "file"
+  )
+)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -2,8 +2,6 @@
 # and then cleans up several variables in preparation for plotting
 process_data <- function(site_data_file, site_info_file, out_file){
   
-  require(tidyverse)
-  
   # Read site info from csv 
   site_info <- readr::read_csv(site_info_file, show_col_types = F)
   

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -2,6 +2,8 @@
 # and then cleans up several variables in preparation for plotting
 process_data <- function(site_data_file, site_info_file, out_file){
   
+  require(tidyverse)
+  
   # Read site info from csv 
   site_info <- readr::read_csv(site_info_file, show_col_types = F)
   

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -1,0 +1,12 @@
+source("3_visualize/src/plot_timeseries.R")
+
+# Create figure 1
+p3_targets_list <- list(
+  tar_target(
+    p3_figure_1_png,
+    plot_nwis_timeseries(out_file = "3_visualize/out/figure_1.png", 
+                         in_file = p2_site_data_styled_rds),
+    format = "file"
+  )
+)
+

--- a/_targets.R
+++ b/_targets.R
@@ -1,10 +1,11 @@
 library(targets)
-source("1_fetch.R")
-source("2_process.R")
-source("3_visualize.R")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+
+source("1_fetch.R")
+source("2_process.R")
+source("3_visualize.R")
 
 # Global parameters
 parameterCd <- '00010'

--- a/_targets.R
+++ b/_targets.R
@@ -1,9 +1,7 @@
 library(targets)
-source("1_fetch/src/download_nwis_site_data.R")
-source("1_fetch/src/nwis_site_info.R")
-source("1_fetch/src/bind_site_data.R")
-source("2_process/src/process_and_style.R")
-source("3_visualize/src/plot_timeseries.R")
+source("1_fetch.R")
+source("2_process.R")
+source("3_visualize.R")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
@@ -12,79 +10,6 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse b
 parameterCd <- '00010'
 startDate <- "2014-05-01" 
 endDate <- "2015-05-01"
-
-
-# For each site, download data and write to csv
-#         Note: this feels inefficient and hard to scale up. How can we "loop" over
-#               multiple sites without making a target specified to each individually?
-p1_targets_list <- list(
-  tar_target(
-    site_data_01427207, 
-    download_nwis_site_data(site_num = "01427207",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate)
-  ),
-  tar_target(
-    site_data_01432160,
-    download_nwis_site_data(site_num = "01432160",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate)
-  ),
-  tar_target(
-    site_data_01436690,
-    download_nwis_site_data(site_num = "01436690",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate)
-  ),
-  tar_target(
-    site_data_01466500,
-    download_nwis_site_data(site_num = "01466500",
-                            parameterCd = parameterCd,
-                            startDate = startDate,
-                            endDate = endDate)
-  ),
-  tar_target(
-    # Merge data from all sites
-    site_data_csv,
-    bind_site_data(out_file = "1_fetch/out/nwis_site_data.csv",
-                   in_data = bind_rows(site_data_01427207, 
-                                       site_data_01432160,
-                                       site_data_01436690,
-                                       site_data_01466500)),
-    format = "file"
-  ),
-  tar_target(
-    # Download pertinent site information for each site
-    site_info_csv,
-    nwis_site_info(out_file = "1_fetch/out/site_info.csv", 
-                   site_data_file = site_data_csv),
-    format = "file"
-  )
-)
-
-# Process and annotate site_data
-p2_targets_list <- list(
-  tar_target(
-    site_data_styled_rds,
-    process_data(site_data_file = site_data_csv, 
-                 site_info_file = site_info_csv,
-                 out_file = "2_process/out/processed_data.rds"),
-    format = "file"
-  )
-)
-
-# Create figure 1
-p3_targets_list <- list(
-  tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(out_file = "3_visualize/out/figure_1.png", 
-                         in_file = site_data_styled_rds),
-    format = "file"
-  )
-)
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p3_targets_list)


### PR DESCRIPTION
I added the phases as separate makefiles and updated target names to include `pX_` where `X` is the phase number. 

One note: When I reorganized the pipeline, I didn't change the functions. However, all of a sudden the functions didn't work unless I used `require(tidyverse)` -- I'm guessing for some reason the `tar_make()` couldn't figure out the `tar_options_set` argument for some reason. Do I need to put the `tar_options_set()` at the top of the appropriate phase makefile? Thanks!

<img width="407" alt="image" src="https://user-images.githubusercontent.com/19958841/173915120-d27e9222-d83c-440c-9fbe-4abb7bddf427.png">
